### PR TITLE
PAL bug fixes/minor updates

### DIFF
--- a/Protocol/PAL/Language/English/Instructions.ini
+++ b/Protocol/PAL/Language/English/Instructions.ini
@@ -90,18 +90,16 @@ train = In this block, you will be presented with an image at
 	Press 'Start' below to see where each image is located 
 	before starting the block.
 
-task = On the following screen, you will be shown the location
-	of several images. You will see each location for 3 seconds.
+task = On the following screen, you will see the location of several 
+	images. You will see each image for 3 seconds.
 
-	You will then see an image at the top of the screen. Your 
-	task is to identify where that image is located.
+	When the images disappear, press and hold the white square.
+	An image will appear at the top of the screen. Your task is to 
+	identify where that image is located.
 
-	To respond, lift your finger from the white square and 
-	touch one of the circles.
-
-	After responding, return your finger to the white square.
+	To respond, lift your finger from the white square and touch 
+	one of the circles, then return your finger to the white square.
 
 	You will receive feedback after each trial.
 
-	Press 'See Image Locations' below to see where each image 
-	is located before starting the block.
+	Press 'See Image Locations' above to see the locations.


### PR DESCRIPTION
Video
- Changed position based on text_button size
- Added fit_mode = "contain" to resize video to fill screen without changing aspect ratio
- Added video restart function
- Added boolean check if first play of video to trigger addition of restart/continue buttons

Text
- Adjusted position/size slightly
- Changed to title/sentence case

Other
- Changed outline shape for Recall stage to circle to better differentiate from hold_button
- Added 'return' to section_start to return to previous function
- Changed block_check_event unbinding for stage_continue_button to block_contingency
- Removed stage end trigger based on number of correct responses to ensure all participants get same number of rewarded trials
- Adjusted add_variable_event call to single line to align with other calls
- Adjusted correction trial check to only trigger if current_block_trial > 0 (i.e., not first run of trial_contingency for that block)
- Added max_run=1 to trial_list constrained shuffle to avoid two or more identical trials in a row

Instructions
- Slightly adjusted text for Recall stage to better fit on screen