### PR TITLE
CPT - Fix Stimulus Duration staircasing bug, add staricasing trial max

### DIFF
--- a/Protocol/CPT/Configuration.ini
+++ b/Protocol/CPT/Configuration.ini
@@ -26,6 +26,7 @@ block_min_rest_duration = 2
 session_duration = 3600
 block_multiplier = 1
 block_trials_base = 120
+block_trials_staircasing = 180
 block_trials_per_flanker_type = 60
 training_block_max_correct = 10
 target_prob_base = 0.33


### PR DESCRIPTION
Switch from continuous staircasing to discrete blocks prevented correct staircasing due to trial outcome requirements in if/else statements.

Removed trial outcome requirement from if/else statements; staircasing should now trigger correctly.

Also added block trial max for staircasing (set to 180 trials/12 blocks of 15) to ensure sufficient trials are allowed for staircasing.